### PR TITLE
Call processMessage after the buffer is sliced

### DIFF
--- a/src/data-input-stream.coffee
+++ b/src/data-input-stream.coffee
@@ -32,10 +32,11 @@ module.exports = class DataInputStream extends EventEmitter
 
 		return if @awaitBytes and @awaitBytes > @buffer.length
 
-		@processMessage @buffer.slice 0, @awaitBytes
+		message = @buffer.slice 0, @awaitBytes
 		@buffer = @buffer.slice @awaitBytes
 		@awaitBytes = 0
 
+		@processMessage message
 		@processData() if @buffer.length > 0
 
 


### PR DESCRIPTION
Calling processMessage before the buffer is sliced sometimes resulted in processing the same message more than once.