### PR TITLE
Fix scanning with startRow or stopRow only

### DIFF
--- a/src/call.coffee
+++ b/src/call.coffee
@@ -12,6 +12,7 @@ module.exports = class Call
 			@called = yes
 			@cb 'timedout'
 		, @timeout
+		debug "operation #{@header.callId} (#{@header.methodName}) called"
 
 
 	complete: (err, data) =>

--- a/src/scan.coffee
+++ b/src/scan.coffee
@@ -71,10 +71,10 @@ module.exports.Scan = class Scan
 
 			if @scannerId
 				req.scannerId = @scannerId
-			else if @startRow and @stopRow
-				req.scan =
-					startRow: @startRow
-					stopRow: @stopRow
+			else if @startRow or @stopRow
+				req.scan = {}
+				req.scan.startRow = @startRow if @startRow
+				req.scan.stopRow = @stopRow if @stopRow
 
 			req.scan.filter = @filter if @filter
 

--- a/test/basic_usage.coffee
+++ b/test/basic_usage.coffee
@@ -491,7 +491,7 @@ describe 'hbase', () ->
 					done()
 
 		it 'should scan the table with startRow and stopRow', (done) ->
-			scan = client.getScanner testTable, '5', '6'
+			scan = client.getScanner testTable, '4', '6'
 
 			scan.next (err, row) ->
 				assert.notOk err, "scan.next returned an error: #{err}"
@@ -501,6 +501,38 @@ describe 'hbase', () ->
 					assert.notOk err, "scan.next returned an error: #{err}"
 					assert.equal Object.keys(row), 0, "should return empty object"
 					done()
+
+		it 'should scan the table with startRow only', (done) ->
+			scan = client.getScanner testTable, '3'
+
+			async.eachSeries [1..testRows.length], (i, cb) ->
+				if i is testRows.length
+					scan.next (err, row) ->
+						assert.notOk err, "scan.next returned an error: #{err}"
+						assert.equal Object.keys(row), 0, "last scan should return empty object"
+						cb()
+				else
+					scan.next (err, row) ->
+						assert.notOk err, "scan.next returned an error: #{err}"
+						assert.equal row.row, testRows[i].row, "rowKey doesn't match"
+						cb()
+			, done
+
+		it 'should scan the table with stopRow only', (done) ->
+			scan = client.getScanner testTable, undefined, '6'
+
+			async.eachSeries [0..2], (i, cb) ->
+				if i is 2
+					scan.next (err, row) ->
+						assert.notOk err, "scan.next returned an error: #{err}"
+						assert.equal Object.keys(row), 0, "last scan should return empty object"
+						cb()
+				else
+					scan.next (err, row) ->
+						assert.notOk err, "scan.next returned an error: #{err}"
+						assert.equal row.row, testRows[i].row, "rowKey doesn't match"
+						cb()
+			, done
 
 		it 'should report invalid filter for scan', (done) ->
 			scan = client.getScanner testTable


### PR DESCRIPTION
Add ability to create scan with only startRow or only stopRow (currently is works only if both are set).