### PR TITLE
Resolve missing hconstants variable for the zookeeper quorum seperator.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -34,7 +34,7 @@ module.exports = class Client extends EventEmitter
 
 		options.zookeeperRoot = options.zookeeperRoot or "/hbase"
 		if options.zookeeper and typeof options.zookeeper.quorum is "string"
-			options.zookeeperHosts = options.zookeeper.quorum.split(SERVERNAME_SEPARATOR)
+			options.zookeeperHosts = options.zookeeper.quorum.split(hconstants.SERVERNAME_SEPARATOR)
 
 		@zk = new ZooKeeperWatcher
 			hosts: options.zookeeperHosts


### PR DESCRIPTION
When using the Zookeeper quorum connection string the split into separate hosts does not work due to a missing variable object.  This changes add the required variable.