### PR TITLE
properly handle comparators in compareFilter

### DIFF
--- a/src/scan.coffee
+++ b/src/scan.coffee
@@ -29,6 +29,10 @@ module.exports.getFilter = getFilter = (filter) ->
 	if filterNameUpper in ['SingleColumnValueFilter']
 		filter[filterName].comparator = getFilter filter[filterName].comparator
 
+	if filter[filterName].compareFilter && filter[filterName].compareFilter.comparator
+		filter[filterName].compareFilter.comparator =
+			getFilter filter[filterName].compareFilter.comparator
+
 	o =
 		name: "org.apache.hadoop.hbase.filter.#{filterNameUpper}"
 	serialized = 'serializedFilter'


### PR DESCRIPTION
regarding https://github.com/falsecz/hbase-rpc-client/issues/62

This fix works with the familyFilter as 
```
        familyFilter: {
          compareFilter: {
            compareOp: 'EQUAL',
            comparator: {
              SubstringComparator: {
                substr: filter.family
              }
            }
          }     
        }
```

though I don't know if this is the best fix or covers every situation where a comparator is used, I suspect not.